### PR TITLE
log: Add caller skip to return useful information

### DIFF
--- a/log/util.go
+++ b/log/util.go
@@ -26,7 +26,7 @@ func buildLogger(name, level string, enableStackTrace bool, fields map[string]in
 	}
 
 	// Build logger
-	logger, err := config.Build()
+	logger, err := config.Build(zap.AddCallerSkip(1))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Calling the functions in log/log.go will display a caller from there. We
want to step up a stack frame to return the caller's caller.

This is documented here:
https://github.com/uber-go/zap/blob/de8aa9e8396ccd3e2c734089fe010747f74d60ce/options.go#L93